### PR TITLE
notes hooked up to storage

### DIFF
--- a/source/backend/storage.js
+++ b/source/backend/storage.js
@@ -118,7 +118,7 @@ export function addLog(date, notes, journal) {
             }
         }
     }
-    
+
     // Input validation for journal: check if a string
     if (typeof (journal) !== 'string') {
         console.error('Journal must be string.');

--- a/source/backend/storage.js
+++ b/source/backend/storage.js
@@ -110,13 +110,15 @@ export function addLog(date, notes, journal) {
     }
 
     // Input validation for notes: check if contains only strings
-    for (let i = 0; i < notes.length; i++) {
-        if (typeof (notes[i]) !== 'string') {
-            console.error('Notes must contain only strings.');
-            return EXIT_FAILURE;
+    if (notes != null) {
+        for (let i = 0; i < notes.length; i++) {
+            if (typeof (notes[i]) !== 'string') {
+                console.error('Notes must contain only strings.');
+                return EXIT_FAILURE;
+            }
         }
     }
-
+    
     // Input validation for journal: check if a string
     if (typeof (journal) !== 'string') {
         console.error('Journal must be string.');
@@ -156,10 +158,12 @@ export function updateLog(date, notes, journal) {
     }
 
     // Input validation for notes: check if contains strings
-    for (let i = 0; i < notes.length; i++) {
-        if (typeof (notes[i]) !== 'string') {
-            console.log('Notes must contain only strings.');
-            return EXIT_FAILURE;
+    if (notes != null) {
+        for (let i = 0; i < notes.length; i++) {
+            if (typeof (notes[i]) !== 'string') {
+                console.log('Notes must contain only strings.');
+                return EXIT_FAILURE;
+            }
         }
     }
 

--- a/source/components/control/control.js
+++ b/source/components/control/control.js
@@ -74,15 +74,17 @@ newLogBtn.addEventListener('click', () => {
         main.appendChild(dailyLog);
 
         dailyLog.addEventListener('cancelLog', () => {
+            console.log('CANCEL');
             main.removeChild(dailyLog); // remove full log
             // editBtn.disabled = false; // allow edit
             populateInbox(); // add previews back
         });
 
         dailyLog.addEventListener('saveLog', () => {
+            console.log('SAVE');
             main.removeChild(dailyLog); // remove full log
             // editBtn.disabled = false; // allow edit
-            addLog(dailyLog.getDate(), [], dailyLog.getJournal());
+            addLog(dailyLog.getDate(), dailyLog.getNotes(), dailyLog.getJournal());
             populateInbox(); // add previews back
         });
     }
@@ -139,7 +141,7 @@ function populateInbox() {
             convertPreviewDate(dailyLog.date), // convert to form {mm/dd/yyyy}
             dailyLog.journal,
             false,
-            false,
+            dailyLog.notes,
             dailyLog.journal.length > 0,
         );
     });
@@ -182,7 +184,7 @@ function createDailyLog(date) {
     dailyLog.populateFields(
         'Daily Log',
         logContent.date,
-        [],
+        logContent.notes,
         logContent.journal,
     );
 
@@ -196,21 +198,21 @@ function createDailyLog(date) {
  * @param {String} date from preview
  */
 function openFullLog(date) {
-    // editBtn.disabled = true; // do not let users mess outside of log
+    editBtn.disabled = true; // do not let users mess outside of log
     removeAllLogs(); // clear out main
     const dailyLog = createDailyLog(date);
 
     // on cancel, reset inbox (populate with whatever we have)
     dailyLog.addEventListener('cancelLog', () => {
         main.removeChild(dailyLog); // remove full daily log from screen
-        // editBtn.disabled = false; // users can edit inbox again
+        editBtn.disabled = false; // users can edit inbox again
         populateInbox(); // add previews
     });
 
     dailyLog.addEventListener('saveLog', () => {
         main.removeChild(dailyLog); // remove full daily log from screen
-        // editBtn.disabled = false; // users can edit inbox again
-        updateLog(dailyLog.getDate(), [], dailyLog.getJournal()); // save changes
+        editBtn.disabled = false; // users can edit inbox again
+        updateLog(dailyLog.getDate(), dailyLog.getNotes(), dailyLog.getJournal()); // save changes
         populateInbox(); // add previews (with changes)
     });
 }

--- a/source/components/daily-log-preview/daily-log-preview.js
+++ b/source/components/daily-log-preview/daily-log-preview.js
@@ -8,8 +8,8 @@ export const PREVIEW_PARAGRAPH_CLASS = 'preview-paragraph';
 export const DAILY_LOG_TITLE = 'Daily Log ';
 
 // Preview constants
-export const NO_PREVIEW_TEXT = 'No preivew text available.';
-const MAX_PREVIEW_LENGTH = 75;
+export const NO_PREVIEW_TEXT = 'No preview text available.';
+const MAX_PREVIEW_LENGTH = 30;
 
 // Icon constants
 const TRACKER_ICON = './icons/tracker';

--- a/source/components/daily-log/daily-log.js
+++ b/source/components/daily-log/daily-log.js
@@ -1,4 +1,4 @@
-import { notesClick } from './notes-script.js';
+import { notesClick, populateListElement } from './notes-script.js';
 import { ARROWICON } from './bullet-helper.js';
 import { setDefaultDate } from '../control/control-helpers.js';
 
@@ -17,7 +17,7 @@ export const PIXELS = 'px';
  * currentEntries[entry] = entry.value
  * 'Let' so can be updated globally
  */
-export const currentEntries = new Map();
+// export var currentEntries = new Map();
 
 /**
  * @module DailyLogPreview
@@ -159,12 +159,51 @@ class DailyLog extends HTMLElement {
             title.textContent = titleOfLog;
             dateBtn.textContent = dateOfLog;
             // ignore notesOfLog for now because not set up
+            if (notesOfLog === null) {
+                console.log('NOT populating notes bc null');
+            } else {
+                /**
+                 * Iterate through each item in the notes array which is an
+                 * object with the bullet style + notes content + call
+                 * helper function to create a bullet + add to notes
+                 */
+                for (let i = 0; i < notesOfLog.length; i++) {
+                    const savedNote = JSON.parse(notesOfLog[i]);
+                    populateListElement(savedNote.bulletStyle, savedNote.noteContent);
+                }
+            }
             journalInput.textContent = journalOfLog;
         };
 
         /* Getter functions */
         this.getDate = () => dateBtn.textContent;
         this.getJournal = () => journalInput.value;
+        this.getNotes = () => {
+            const bulletList = notes.childNodes; // list of notes
+            const notesArr = []; // will hold content of each note
+            let j = 0;
+
+            /**
+             * If children of the list is 2 that represents the placeholder + title
+             * so no notes were recorded. If more than that, iterate through each
+             * bullet continer object to grab content + bullet style + save in array.
+             */
+            if (bulletList.length > 2) {
+                for (let i = 2; i < bulletList.length; i++) {
+                    const bulletType = bulletList[i]; // container for bullet and text
+                    const noteEntry = bulletType.childNodes[1]; // kids are (0) bullet & (1) entry 
+                    const saveNote = { // note object to store in arr
+                        bulletStyle: bulletType.getAttribute('bullet-type'),
+                        noteContent: noteEntry.value,
+                    };
+                    notesArr[j++] = JSON.stringify(saveNote);
+                }
+                return notesArr;
+            } else {
+                console.log('no bullet points, just placeholder');
+                return null;
+            }
+        }
 
         /* Events */
         const cancelLogEvent = new CustomEvent('cancelLog', {

--- a/source/components/daily-log/daily-log.js
+++ b/source/components/daily-log/daily-log.js
@@ -191,7 +191,7 @@ class DailyLog extends HTMLElement {
             if (bulletList.length > 2) {
                 for (let i = 2; i < bulletList.length; i++) {
                     const bulletType = bulletList[i]; // container for bullet and text
-                    const noteEntry = bulletType.childNodes[1]; // kids are (0) bullet & (1) entry 
+                    const noteEntry = bulletType.childNodes[1]; // kids are (0) bullet & (1) entry
                     const saveNote = { // note object to store in arr
                         bulletStyle: bulletType.getAttribute('bullet-type'),
                         noteContent: noteEntry.value,
@@ -203,7 +203,7 @@ class DailyLog extends HTMLElement {
                 console.log('no bullet points, just placeholder');
                 return null;
             }
-        }
+        };
 
         /* Events */
         const cancelLogEvent = new CustomEvent('cancelLog', {

--- a/source/components/daily-log/notes-script.js
+++ b/source/components/daily-log/notes-script.js
@@ -1,9 +1,17 @@
-import { currentEntries, autoGrow } from './daily-log.js';
+// import { currentEntries, autoGrow } from './daily-log.js';
+import { autoGrow } from './daily-log.js';
 import { cancel, click, start } from './long-press.js';
 import { DEFAULTBULLET, IMPORTANTBULLET, EVENTBULLET } from './bullet-helper.js';
 
 /* global variable to keep track of the most recently changed bullet */
 let mostRecentBullet = null;
+
+/**
+ * dictionary to keep track of current note entries
+ * currentEntries[entry] = entry.value
+ * 'Let' so can be updated globally
+ */
+const currentEntries = new Map();
 
 /**
  * @function enterKeyPressed
@@ -192,7 +200,6 @@ export function changeBullet(event) {
  * @function createListElement
  * Creates a new note entry element and appends it to the Notes section
  */
-
 export function createListElement() {
     /* Get notes section container from Shadow DOM */
     const notesContainer = document.querySelector('daily-log').shadowRoot.getElementById('notes-container');
@@ -254,4 +261,97 @@ export function createListElement() {
 
     /* Automatically focus on new element's input area */
     noteEntry.focus();
+}
+
+/**
+ * @method populateListElement
+ * Yes this is a very redundant function. (TODO: rely on above fxn).
+ * Will repopulate the list of bullet points from local storage
+ * by creating a bullet point, adding content, and setting bullet style.
+ * @param {*} style 
+ * @param {*} text 
+ */
+export function populateListElement(style, text) {
+    /* Get notes section container from Shadow DOM */
+    const notesContainer = document.querySelector('daily-log').shadowRoot.getElementById('notes-container');
+
+    /** List element structure: <span><span></span><input></input></span>
+     * Span element holds bullet container and input area for note entry
+     */
+    const listElement = document.createElement('span');
+    const bulletContainer = document.createElement('span');
+    const noteEntry = document.createElement('textarea');
+
+    /* Set attributes for styling */
+    listElement.setAttribute('id', 'list-element');
+    bulletContainer.setAttribute('id', 'bullet-container');
+    noteEntry.setAttribute('id', 'note-entry');
+    noteEntry.value = text;
+
+    /* Add default bullet text node to entry */
+    let bulletPoint = null;
+
+    switch (style) {
+        case 'default-bullet':
+            bulletPoint = document.createTextNode(DEFAULTBULLET);
+            break;
+        case 'important-bullet':
+            bulletPoint = document.createTextNode(IMPORTANTBULLET);
+            break;
+        case 'event-bullet':
+            bulletPoint = document.createTextNode(EVENTBULLET);
+            break;
+        case 'checkbox-bullet':
+            const checkbox = document.createElement('input');
+            checkbox.setAttribute('type', 'checkbox');
+            bulletPoint = checkbox
+            break;
+    }
+    
+    /* Set 'bullet-type' attribute for this list element */
+    bulletContainer.appendChild(bulletPoint);
+    listElement.setAttribute('bullet-type', style);
+
+    /** Note entry textarea should default to one line and dynamically grow with input
+     * Note entry 'new' attribute should be set to true since it is a new entry
+     */
+    noteEntry.setAttribute('rows', '1');
+    noteEntry.oninput = function () { autoGrow(this); };
+    noteEntry.setAttribute('new', 'true');
+
+    /* Append children to List Element */
+    listElement.appendChild(bulletContainer);
+    listElement.appendChild(noteEntry);
+
+    /* Add event listeners */
+    noteEntry.addEventListener('keyup', enterKeyPressed);
+    noteEntry.addEventListener('keydown', deleteEntry);
+    /* Prevent user from creating a newline with 'Enter' within note entry textarea */
+    noteEntry.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+        }
+    });
+
+    /* Add longpress event listeners to List Element to launch bullet modal */
+    bulletContainer.addEventListener('mousedown', start);
+    bulletContainer.addEventListener('touchstart', start);
+    bulletContainer.addEventListener('click', click);
+    bulletContainer.addEventListener('mouseout', cancel);
+    bulletContainer.addEventListener('touchend', cancel);
+    bulletContainer.addEventListener('touchleave', cancel);
+    bulletContainer.addEventListener('touchcancel', cancel);
+    bulletContainer.oncontextmenu = (e) => {
+        e.preventDefault();
+    };
+
+    /* Append list element to Notes section */
+    notesContainer.appendChild(listElement);
+
+    /* Automatically focus on new element's input area */
+    noteEntry.focus();
+
+    /* Remove placeholder */
+    const notesPlaceholder = document.querySelector('daily-log').shadowRoot.getElementById('notes-placeholder');
+    notesPlaceholder.style.display = 'none';
 }

--- a/source/components/daily-log/notes-script.js
+++ b/source/components/daily-log/notes-script.js
@@ -268,8 +268,8 @@ export function createListElement() {
  * Yes this is a very redundant function. (TODO: rely on above fxn).
  * Will repopulate the list of bullet points from local storage
  * by creating a bullet point, adding content, and setting bullet style.
- * @param {*} style 
- * @param {*} text 
+ * @param {String} style (type of bullet like default)
+ * @param {String} text (content user typed)
  */
 export function populateListElement(style, text) {
     /* Get notes section container from Shadow DOM */
@@ -291,23 +291,18 @@ export function populateListElement(style, text) {
     /* Add default bullet text node to entry */
     let bulletPoint = null;
 
-    switch (style) {
-        case 'default-bullet':
-            bulletPoint = document.createTextNode(DEFAULTBULLET);
-            break;
-        case 'important-bullet':
-            bulletPoint = document.createTextNode(IMPORTANTBULLET);
-            break;
-        case 'event-bullet':
-            bulletPoint = document.createTextNode(EVENTBULLET);
-            break;
-        case 'checkbox-bullet':
-            const checkbox = document.createElement('input');
-            checkbox.setAttribute('type', 'checkbox');
-            bulletPoint = checkbox
-            break;
+    if (style === 'important-bullet') {
+        bulletPoint = document.createTextNode(IMPORTANTBULLET);
+    } else if (style === 'event-bullet') {
+        bulletPoint = document.createTextNode(EVENTBULLET);
+    } else if (style === 'checkbox-bullet') {
+        const checkbox = document.createElement('input');
+        checkbox.setAttribute('type', 'checkbox');
+        bulletPoint = checkbox;
+    } else {
+        bulletPoint = document.createTextNode(DEFAULTBULLET);
     }
-    
+
     /* Set 'bullet-type' attribute for this list element */
     bulletContainer.appendChild(bulletPoint);
     listElement.setAttribute('bullet-type', style);

--- a/source/index.html
+++ b/source/index.html
@@ -42,7 +42,6 @@
             <popup-modal id="delete-selected-modal"></popup-modal>
             <bullet-modal id="bullet-modal"></bullet-modal>
         </main>
-        <!-- <script type="module" src="./add-component.js"></script> -->
         <script type="module" src="./components/control/control.js"></script>
         <script type="module" src="./components/daily-log/daily-log.js"></script>
         <script type="module" src="./components/daily-log/bullet-modal.js"></script>

--- a/source/styles/daily-log.css
+++ b/source/styles/daily-log.css
@@ -190,6 +190,7 @@ h3 {
     padding: var(--wrap-top) var(--wrap-edge) var(--wrap-top) var(--wrap-edge);
     margin-left: var(--pad-screen-edge);
     margin-right: var(--pad-screen-edge);
+    padding-bottom: 100px;
 }
 
 /* ===== same across browsers ===== */


### PR DESCRIPTION
**PR**: Control

Minor edit: made daily log bottom longer so it won't get covered by a footer on small devices.

Should clean up some redundant code in the future + add tests (did all manual).

If user writes notes, we save the content + bullet style so when we open the log later, it has the correct style + content. Also edits storage when user deletes some/all notes.